### PR TITLE
Werkzeug import fix

### DIFF
--- a/flask_babel2/__init__.py
+++ b/flask_babel2/__init__.py
@@ -16,7 +16,7 @@ import os
 
 from babel import Locale, dates, numbers, support
 from flask import _app_ctx_stack, _request_ctx_stack, current_app, has_request_context
-from werkzeug import ImmutableDict
+from werkzeug.datastructures import ImmutableDict
 
 from flask_babel2._compat import string_types
 from flask_babel2.speaklater import LazyString


### PR DESCRIPTION
Werkzeug has deprecated most of their top level imports. Fix was needed. Details: https://werkzeug.palletsprojects.com/en/master/changes/#version-1-0-0

ImmutableDict Ref: https://werkzeug.palletsprojects.com/en/0.16.x/datastructures/?highlight=immutabledict#werkzeug.datastructures.ImmutableDict